### PR TITLE
Round off percentage blocked

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -49,7 +49,7 @@
           </tr>
           <tr>
             <td class="key text-left"><small>Ads Percentage Today</small> </td>
-            <td class="value text-right"><small>{{Math.round(raw.ads_percentage_today)}}</small></td>
+            <td class="value text-right"><small>{{Math.round(raw.ads_percentage_today)}}%</small></td>
           </tr>
           <tr>
             <td class="key text-left"><small>Unique Domains</small> </td>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -49,7 +49,7 @@
           </tr>
           <tr>
             <td class="key text-left"><small>Ads Percentage Today</small> </td>
-            <td class="value text-right"><small>{{raw.ads_percentage_today}}</small></td>
+            <td class="value text-right"><small>{{Math.round(raw.ads_percentage_today)}}</small></td>
           </tr>
           <tr>
             <td class="key text-left"><small>Unique Domains</small> </td>


### PR DESCRIPTION
This rounds off "Ads Percentage Today", which otherwise shows a really long decimal.

Tested under node v8.11.2 on Ubuntu 18.04 - screenshot on  [discourse.pi-hole.net](https://discourse.pi-hole.net/t/pidns-stat-a-tray-app-for-mac-users/9931/2?u=robgill)